### PR TITLE
Refactor: use Randomable class method to generate random post code

### DIFF
--- a/src/Fakers/Address/PostCodeFaker.php
+++ b/src/Fakers/Address/PostCodeFaker.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace AliYavari\PersianFaker\Fakers\Address;
 
 use AliYavari\PersianFaker\Contracts\FakerInterface;
+use AliYavari\PersianFaker\Cores\Randomable;
 
 /**
  * @implements \AliYavari\PersianFaker\Contracts\FakerInterface<string>
  */
 class PostCodeFaker implements FakerInterface
 {
+    /** @use \AliYavari\PersianFaker\Cores\Randomable<int, int> */
+    use Randomable;
+
     public function __construct(protected bool $withSeparator = false) {}
 
     public function generate(): string
@@ -25,13 +29,11 @@ class PostCodeFaker implements FakerInterface
      */
     protected function generateRandomPostCode(): string
     {
-        $postCode = '';
+        $validDigits = range(1, 9);
 
-        for ($i = 1; $i <= 10; $i++) {
-            $postCode .= random_int(1, 9);
-        }
+        $digits = $this->getMultipleRandomElements($validDigits, 10);
 
-        return $postCode;
+        return implode('', $digits);
     }
 
     protected function addSeparator(string $postCode): string

--- a/tests/Fakers/Address/PostCodeFakerTest.php
+++ b/tests/Fakers/Address/PostCodeFakerTest.php
@@ -12,7 +12,7 @@ class PostCodeFakerTest extends TestCase
     public function test_it_returns_post_code_without_separator(): void
     {
         $faker = new PostCodeFaker;
-        $postCode = $faker->generate();
+        $postCode = $faker->generate(); // Expected format: ##########
 
         $this->assertIsString($postCode);
         $this->assertEquals(10, strlen($postCode));
@@ -22,11 +22,11 @@ class PostCodeFakerTest extends TestCase
     public function test_it_returns_post_code_with_separator(): void
     {
         $faker = new PostCodeFaker(withSeparator: true);
-        $postCode = $faker->generate();
+        $postCode = $faker->generate(); // Expected format: #####-#####
 
         $this->assertIsString($postCode);
         $this->assertEquals(11, strlen($postCode));
-        $this->assertEquals(5, strpos($postCode, '-')); // Valid format: #####-#####
+        $this->assertEquals(5, strpos($postCode, '-'));
         $this->assertTrue($this->areDigitsNumeric($postCode));
     }
 


### PR DESCRIPTION
The use of the `getMultipleRandomElements()` method from the `Randomable` trait has been replaced with a manual implementation for generating random digits for postal codes.

Additionally, in the postal code tests, expected formats have been added to clarify the test assertions.

