### PR TITLE
Refactor: use simple picker and mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.18.1",
+        "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^1.12.7",
         "phpunit/phpunit": "^11.5",
         "rector/rector": "^1.2.8",

--- a/src/Fakers/Address/AddressFaker.php
+++ b/src/Fakers/Address/AddressFaker.php
@@ -4,38 +4,20 @@ declare(strict_types=1);
 
 namespace AliYavari\PersianFaker\Fakers\Address;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
-use AliYavari\PersianFaker\Contracts\FakerInterface;
-use AliYavari\PersianFaker\Cores\Randomable;
+use AliYavari\PersianFaker\Fakers\SimplePicker;
 
 /**
  * Generates a random full address in Iran
  *
- * @implements \AliYavari\PersianFaker\Contracts\FakerInterface<string>
+ * @extends \AliYavari\PersianFaker\Fakers\SimplePicker<int, string>
  */
-class AddressFaker implements FakerInterface
+class AddressFaker extends SimplePicker
 {
-    /** @use \AliYavari\PersianFaker\Cores\Randomable<int, string> */
-    use Randomable;
-
-    /**
-     * @var list<string>
-     */
-    protected array $addresses;
-
-    /**
-     * @param  \AliYavari\PersianFaker\Contracts\DataLoaderInterface<int, string>  $loader
-     */
-    public function __construct(DataLoaderInterface $loader)
-    {
-        $this->addresses = $loader->get();
-    }
-
     /**
      * This returns a fake full address
      */
     public function generate(): string
     {
-        return $this->getOneRandomElement($this->addresses);
+        return parent::generate();
     }
 }

--- a/src/Fakers/Address/CityFaker.php
+++ b/src/Fakers/Address/CityFaker.php
@@ -4,38 +4,20 @@ declare(strict_types=1);
 
 namespace AliYavari\PersianFaker\Fakers\Address;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
-use AliYavari\PersianFaker\Contracts\FakerInterface;
-use AliYavari\PersianFaker\Cores\Randomable;
+use AliYavari\PersianFaker\Fakers\SimplePicker;
 
 /**
  * Generates a random city name in Iran
  *
- * @implements \AliYavari\PersianFaker\Contracts\FakerInterface<string>
+ * @extends \AliYavari\PersianFaker\Fakers\SimplePicker<int, string>
  */
-class CityFaker implements FakerInterface
+class CityFaker extends SimplePicker
 {
-    /** @use \AliYavari\PersianFaker\Cores\Randomable<int, string> */
-    use Randomable;
-
-    /**
-     * @var list<string>
-     */
-    protected array $cities;
-
-    /**
-     * @param  \AliYavari\PersianFaker\Contracts\DataLoaderInterface<int, string>  $loader
-     */
-    public function __construct(DataLoaderInterface $loader)
-    {
-        $this->cities = $loader->get();
-    }
-
     /**
      * This returns a fake city name
      */
     public function generate(): string
     {
-        return $this->getOneRandomElement($this->cities);
+        return parent::generate();
     }
 }

--- a/src/Fakers/Address/StateFaker.php
+++ b/src/Fakers/Address/StateFaker.php
@@ -4,38 +4,20 @@ declare(strict_types=1);
 
 namespace AliYavari\PersianFaker\Fakers\Address;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
-use AliYavari\PersianFaker\Contracts\FakerInterface;
-use AliYavari\PersianFaker\Cores\Randomable;
+use AliYavari\PersianFaker\Fakers\SimplePicker;
 
 /**
  * Generates a random state name in Iran
  *
- * @implements \AliYavari\PersianFaker\Contracts\FakerInterface<string>
+ * @extends \AliYavari\PersianFaker\Fakers\SimplePicker<int, string>
  */
-class StateFaker implements FakerInterface
+class StateFaker extends SimplePicker
 {
-    /** @use \AliYavari\PersianFaker\Cores\Randomable<int, string> */
-    use Randomable;
-
-    /**
-     * @var list<string>
-     */
-    protected array $states;
-
-    /**
-     * @param  \AliYavari\PersianFaker\Contracts\DataLoaderInterface<int, string>  $loader
-     */
-    public function __construct(DataLoaderInterface $loader)
-    {
-        $this->states = $loader->get();
-    }
-
     /**
      * This returns a fake state name
      */
     public function generate(): string
     {
-        return $this->getOneRandomElement($this->states);
+        return parent::generate();
     }
 }

--- a/src/Fakers/Address/StreetNameFaker.php
+++ b/src/Fakers/Address/StreetNameFaker.php
@@ -4,38 +4,20 @@ declare(strict_types=1);
 
 namespace AliYavari\PersianFaker\Fakers\Address;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
-use AliYavari\PersianFaker\Contracts\FakerInterface;
-use AliYavari\PersianFaker\Cores\Randomable;
+use AliYavari\PersianFaker\Fakers\SimplePicker;
 
 /**
  * Generates a random street name in Iran
  *
- * @implements \AliYavari\PersianFaker\Contracts\FakerInterface<string>
+ * @extends \AliYavari\PersianFaker\Fakers\SimplePicker<int, string>
  */
-class StreetNameFaker implements FakerInterface
+class StreetNameFaker extends SimplePicker
 {
-    /** @use \AliYavari\PersianFaker\Cores\Randomable<int, string> */
-    use Randomable;
-
     /**
-     * @var list<string>
-     */
-    protected array $streetNames;
-
-    /**
-     * @param  \AliYavari\PersianFaker\Contracts\DataLoaderInterface<int, string>  $loader
-     */
-    public function __construct(DataLoaderInterface $loader)
-    {
-        $this->streetNames = $loader->get();
-    }
-
-    /**
-     * The returns a fake
+     * This returns a fake street name
      */
     public function generate(): string
     {
-        return $this->getOneRandomElement($this->streetNames);
+        return parent::generate();
     }
 }

--- a/src/Fakers/Person/LastNameFaker.php
+++ b/src/Fakers/Person/LastNameFaker.php
@@ -4,38 +4,20 @@ declare(strict_types=1);
 
 namespace AliYavari\PersianFaker\Fakers\Person;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
-use AliYavari\PersianFaker\Contracts\FakerInterface;
-use AliYavari\PersianFaker\Cores\Randomable;
+use AliYavari\PersianFaker\Fakers\SimplePicker;
 
 /**
  * Generates a random last name in Persian for Iranian individuals.
  *
- * @implements \AliYavari\PersianFaker\Contracts\FakerInterface<string>
+ * @extends \AliYavari\PersianFaker\Fakers\SimplePicker<int, string>
  */
-class LastNameFaker implements FakerInterface
+class LastNameFaker extends SimplePicker
 {
-    /** @use \AliYavari\PersianFaker\Cores\Randomable<int, string> */
-    use Randomable;
-
-    /**
-     * @var list<string>
-     */
-    protected array $names;
-
-    /**
-     * @param  \AliYavari\PersianFaker\Contracts\DataLoaderInterface<int, string>  $loader
-     */
-    public function __construct(DataLoaderInterface $loader)
-    {
-        $this->names = $loader->get();
-    }
-
     /**
      * This returns a fake last name
      */
     public function generate(): string
     {
-        return $this->getOneRandomElement($this->names);
+        return parent::generate();
     }
 }

--- a/src/Fakers/Phone/StatePhonePrefixFaker.php
+++ b/src/Fakers/Phone/StatePhonePrefixFaker.php
@@ -4,38 +4,20 @@ declare(strict_types=1);
 
 namespace AliYavari\PersianFaker\Fakers\Phone;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
-use AliYavari\PersianFaker\Contracts\FakerInterface;
-use AliYavari\PersianFaker\Cores\Randomable;
+use AliYavari\PersianFaker\Fakers\SimplePicker;
 
 /**
  * Generates a random state phone prefix in Iran.
  *
- * @implements \AliYavari\PersianFaker\Contracts\FakerInterface<string>
+ * @extends \AliYavari\PersianFaker\Fakers\SimplePicker<string, string>
  */
-class StatePhonePrefixFaker implements FakerInterface
+class StatePhonePrefixFaker extends SimplePicker
 {
-    /** @use \AliYavari\PersianFaker\Cores\Randomable<string, string> */
-    use Randomable;
-
-    /**
-     * @var array<string, string>
-     */
-    protected array $phonePrefixes;
-
-    /**
-     * @param  \AliYavari\PersianFaker\Contracts\DataLoaderInterface<string, string>  $loader
-     */
-    public function __construct(DataLoaderInterface $loader)
-    {
-        $this->phonePrefixes = $loader->get();
-    }
-
     /**
      * This returns a fake state phone prefix
      */
     public function generate(): string
     {
-        return $this->getOneRandomElement($this->phonePrefixes);
+        return parent::generate();
     }
 }

--- a/src/Fakers/SimplePicker.php
+++ b/src/Fakers/SimplePicker.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AliYavari\PersianFaker\Fakers;
+
+use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
+use AliYavari\PersianFaker\Contracts\FakerInterface;
+use AliYavari\PersianFaker\Cores\Randomable;
+
+/**
+ * Returns a randomly selected element from the loaded one-dimensional data array.
+ *
+ * This method leverages the `Randomable` trait to pick a single random element
+ * from the dataset provided by the `DataLoaderInterface`. It ensures consistent
+ * and reusable logic for random selection across all child classes.
+ *
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @implements \AliYavari\PersianFaker\Contracts\FakerInterface<TValue>
+ */
+abstract class SimplePicker implements FakerInterface
+{
+    /** @use \AliYavari\PersianFaker\Cores\Randomable<TKey, TValue> */
+    use Randomable;
+
+    /**
+     * @var array<TKey, TValue>
+     */
+    protected array $data;
+
+    /**
+     * @param  \AliYavari\PersianFaker\Contracts\DataLoaderInterface<TKey, TValue>  $loader
+     */
+    public function __construct(DataLoaderInterface $loader)
+    {
+        $this->data = $loader->get();
+    }
+
+    /**
+     * This returns a random element
+     *
+     * @return TValue
+     */
+    public function generate()
+    {
+        return $this->getOneRandomElement($this->data);
+    }
+}

--- a/tests/Fakers/Address/AddressFakerTest.php
+++ b/tests/Fakers/Address/AddressFakerTest.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Address;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Fakers\Address\AddressFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class AddressFakerTest extends TestCase
 {
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $addresses;
+    protected array $addresses = ['address 1', 'address 4', 'address 3', 'address 2'];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('address.addresses');
-
-        $this->addresses = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->addresses);
     }
 
     public function test_it_returns_fake_address(): void

--- a/tests/Fakers/Address/CityFakerTest.php
+++ b/tests/Fakers/Address/CityFakerTest.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Address;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Fakers\Address\CityFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class CityFakerTest extends TestCase
 {
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $cities;
+    protected array $cities = ['city 1', 'city 2', 'city 3', 'city 4'];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('address.cities');
-
-        $this->cities = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->cities);
     }
 
     public function test_it_returns_fake_city(): void

--- a/tests/Fakers/Address/SecondaryAddressFakerTest.php
+++ b/tests/Fakers/Address/SecondaryAddressFakerTest.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Address;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Fakers\Address\SecondaryAddressFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class SecondaryAddressFakerTest extends TestCase
 {
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $secondaryAddPrefixes;
+    protected array $secondaryAddPrefixes = ['floor', 'unit', 'building'];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('address.secondary_address_prefixes');
-
-        $this->secondaryAddPrefixes = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->secondaryAddPrefixes);
     }
 
     public function test_it_returns_random_secondary_address_prefix(): void
@@ -36,7 +35,7 @@ class SecondaryAddressFakerTest extends TestCase
     public function test_it_returns_fake_secondary_address(): void
     {
         $faker = new SecondaryAddressFaker($this->loader);
-        $secondaryAddress = $faker->generate(); // Expected format: طبقه 12
+        $secondaryAddress = $faker->generate(); // Expected format: floor 12
 
         [$prefix,$number] = explode(' ', $secondaryAddress);
 

--- a/tests/Fakers/Address/StateFakerTest.php
+++ b/tests/Fakers/Address/StateFakerTest.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Address;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Fakers\Address\StateFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class StateFakerTest extends TestCase
 {
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $states;
+    protected array $states = ['Yazd', 'Tehran', 'Qom', 'Shiraz'];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('address.states');
-
-        $this->states = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->states);
     }
 
     public function test_it_returns_fake_state(): void

--- a/tests/Fakers/Address/StreetNameFakerTest.php
+++ b/tests/Fakers/Address/StreetNameFakerTest.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Address;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Fakers\Address\StreetNameFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class StreetNameFakerTest extends TestCase
 {
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $streetNames;
+    protected array $streetNames = ['name one', 'name two', 'name three', 'name 4'];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('address.street_names');
-
-        $this->streetNames = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->streetNames);
     }
 
     public function test_it_returns_fake_street_name(): void

--- a/tests/Fakers/Person/FirstNameFakerTest.php
+++ b/tests/Fakers/Person/FirstNameFakerTest.php
@@ -4,28 +4,30 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Person;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Cores\Arrayable;
 use AliYavari\PersianFaker\Exceptions\InvalidGenderException;
 use AliYavari\PersianFaker\Fakers\Person\FirstNameFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class FirstNameFakerTest extends TestCase
 {
     use Arrayable;
 
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $names;
+    protected array $names = [
+        'male' => ['male one', 'male two', 'male three'],
+        'female' => ['female one', 'female two', 'female three'],
+    ];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('person.first_names');
-
-        $this->names = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->names);
     }
 
     public function test_gender_validation_passes_with_null_gender(): void

--- a/tests/Fakers/Person/LastNameFakerTest.php
+++ b/tests/Fakers/Person/LastNameFakerTest.php
@@ -4,23 +4,22 @@ declare(strict_types=1);
 
 namespace AliYavari\PersianFaker\Fakers\Person;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class LastNameFakerTest extends TestCase
 {
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $lastNames;
+    protected array $lastNames = ['name one', 'name two', 'name three', 'name four'];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('person.last_names');
-
-        $this->lastNames = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->lastNames);
     }
 
     public function test_it_returns_fake_last_name(): void

--- a/tests/Fakers/Person/TitleFakerTest.php
+++ b/tests/Fakers/Person/TitleFakerTest.php
@@ -4,28 +4,30 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Person;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Cores\Arrayable;
 use AliYavari\PersianFaker\Exceptions\InvalidGenderException;
 use AliYavari\PersianFaker\Fakers\Person\TitleFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class TitleFakerTest extends TestCase
 {
     use Arrayable;
 
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $titles;
+    protected array $titles = [
+        'male' => ['Mr.', 'Sr.'],
+        'female' => ['Ms.', 'Mrs.', 'Miss.'],
+    ];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('person.titles');
-
-        $this->titles = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->titles);
     }
 
     public function test_gender_validation_passes_with_null_gender(): void

--- a/tests/Fakers/Phone/CellPhoneFakerTest.php
+++ b/tests/Fakers/Phone/CellPhoneFakerTest.php
@@ -4,29 +4,32 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Phone;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Cores\Arrayable;
 use AliYavari\PersianFaker\Cores\Randomable;
 use AliYavari\PersianFaker\Exceptions\InvalidMobileProviderException;
 use AliYavari\PersianFaker\Fakers\Phone\CellPhoneFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class CellPhoneFakerTest extends TestCase
 {
     use Arrayable, Randomable;
 
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $phonePrefixes;
+    protected array $phonePrefixes = [
+        'provider_one' => ['0911', '0912', '0913'],
+        'provider_two' => ['0921', '0922', '0933'],
+        'provider three' => ['0941', '0942', '0943'],
+    ];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('phone.mobile_prefixes');
-
-        $this->phonePrefixes = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->phonePrefixes);
     }
 
     public function test_provider_validation_passes_with_null_provider(): void

--- a/tests/Fakers/Phone/PhoneNumberFakerTest.php
+++ b/tests/Fakers/Phone/PhoneNumberFakerTest.php
@@ -4,28 +4,27 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Phone;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Cores\Randomable;
 use AliYavari\PersianFaker\Exceptions\InvalidStateNameException;
 use AliYavari\PersianFaker\Fakers\Phone\PhoneNumberFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class PhoneNumberFakerTest extends TestCase
 {
     use Randomable;
 
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $statePrefixes;
+    protected array $statePrefixes = ['yazd' => '035', 'teh' => '021', 'esf' => '031', 'gil' => '013'];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('phone.state_prefixes');
-
-        $this->statePrefixes = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->statePrefixes);
     }
 
     public function test_state_validation_passes_with_null_state(): void

--- a/tests/Fakers/Phone/StatePhonePrefixFakerTest.php
+++ b/tests/Fakers/Phone/StatePhonePrefixFakerTest.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\Fakers\Phone;
 
-use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use AliYavari\PersianFaker\Fakers\Phone\StatePhonePrefixFaker;
 use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
 use Tests\TestCase;
 
 class StatePhonePrefixFakerTest extends TestCase
 {
-    protected DataLoaderInterface $loader;
+    protected $loader;
 
-    protected array $phonePrefixes;
+    protected array $statePrefixes = ['yazd' => '035', 'teh' => '021', 'esf' => '031', 'gil' => '013'];
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->loader = new DataLoader('phone.state_prefixes');
-
-        $this->phonePrefixes = $this->loader->get();
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->statePrefixes);
     }
 
     public function test_it_returns_fake_state_prefix(): void
@@ -30,6 +29,6 @@ class StatePhonePrefixFakerTest extends TestCase
         $phonePrefix = $faker->generate();
 
         $this->assertIsString($phonePrefix);
-        $this->assertContains($phonePrefix, $this->phonePrefixes);
+        $this->assertContains($phonePrefix, $this->statePrefixes);
     }
 }

--- a/tests/Fakers/SimplePickerTest.php
+++ b/tests/Fakers/SimplePickerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fakers\Address;
+
+use AliYavari\PersianFaker\Fakers\SimplePicker;
+use AliYavari\PersianFaker\Loaders\DataLoader;
+use Mockery;
+use Tests\TestCase;
+
+class SimplePickerTest extends TestCase
+{
+    protected $loader;
+
+    protected array $simpleArray = ['element 1', 'element 4', 'element 3', 'element 2'];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loader = Mockery::mock(DataLoader::class);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->simpleArray);
+    }
+
+    public function test_it_returns_random_element_from_loaded_data(): void
+    {
+        $faker = new class($this->loader) extends SimplePicker {};
+        $element = $faker->generate();
+
+        $this->assertContains($element, $this->simpleArray);
+    }
+}


### PR DESCRIPTION
To test units more isolate, Unit tests have been changed to use mockery/mockery and mock objects for their data loader dependency.
Additionally, some fakers, which only pick one random element from one dimensional array, have been refactored to use one parent class, `SimplePicker`.