### PR TITLE
Chore: make issue templates simpler

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,18 +1,10 @@
-name: "🐛 Bug Report"
+name: "Bug Report"
 description: "Report something that's broken."
 labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: "## 🐞 Bug Report\nPlease provide the details below to help us quickly identify and resolve the issue."
-
-  - type: input
-    id: title
-    attributes:
-      label: "Bug Title"
-      placeholder: "A short and clear description of the issue."
-    validations:
-      required: true
+      value: "## Bug Report\nPlease provide the details below to help us quickly identify and resolve the issue."
 
   - type: input
     id: package-version
@@ -48,7 +40,7 @@ body:
       description: "What should have happened?"
       placeholder: "I expected the app to..."
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: actual
@@ -57,7 +49,7 @@ body:
       description: "What actually happened?"
       placeholder: "Instead, this happened..."
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: steps

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: ❓ General Question / Discussion
+  - name: General Question / Discussion
     url: https://github.com/amyavari/persian-faker-php/discussions
     about: "For general discussions, questions, or help, use GitHub Discussions."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,18 +1,10 @@
-name: "✨ Feature Request"
+name: "Feature Request"
 description: "Suggest a new feature or improvement."
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
-      value: "## 🌟 Feature Request\nDescribe your suggestion."
-
-  - type: input
-    id: title
-    attributes:
-      label: "Feature Title"
-      placeholder: "A short and clear name for the feature."
-    validations:
-      required: true
+      value: "## Feature Request\nDescribe your suggestion."
 
   - type: textarea
     id: description


### PR DESCRIPTION
### What is the reason for this PR?

Issue templates for bug reports and feature requests had extra title input, emoji and required field. They are removed to make people contribution easier.

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [ ] New features and changes are [documented](../README.md)

### Summary of changes

- Extra titles are removed.
- Extra emojis are removed.
- In bug report template, expected and actual sections are changed to be optional.

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer