### PR TITLE
Test: follow conventions and separate necessary tests

### DIFF
--- a/tests/Cores/RandomableTest.php
+++ b/tests/Cores/RandomableTest.php
@@ -40,6 +40,11 @@ class RandomableTest extends TestCase
         $this->expectExceptionMessage('The number of returned elements must be 1 or more, 0 is given.');
 
         $this->getMultipleRandomElements($data, 0);
+    }
+
+    public function test_it_throws_an_exception_if_number_of_returned_elements_is_negative(): void
+    {
+        $data = ['item_one', 'item_two', 'item_three', 'item_four', 'item_five'];
 
         $this->expectException(InvalidElementNumberException::class);
         $this->expectExceptionMessage('The number of returned elements must be 1 or more, -1 is given.');

--- a/tests/Fakers/Payment/CardNumberFakerTest.php
+++ b/tests/Fakers/Payment/CardNumberFakerTest.php
@@ -70,7 +70,7 @@ class CardNumberFakerTest extends TestCase
         $faker = new CardNumberFaker($this->loader, bank: $bank);
         $bin = $this->callProtectedMethod($faker, 'getBin');
 
-        $this->assertSame($bin, $this->banksBins[$bank]);
+        $this->assertSame($this->banksBins[$bank], $bin);
     }
 
     public function test_it_generate_random_nine_digit_number(): void
@@ -159,7 +159,7 @@ class CardNumberFakerTest extends TestCase
         $this->assertIsString($cardNumber);
         $this->assertIsNumeric($cardNumber);
         $this->assertSame(16, strlen($cardNumber));
-        $this->assertSame(substr($cardNumber, 0, 6), $this->banksBins[$bank]);
+        $this->assertSame($this->banksBins[$bank], substr($cardNumber, 0, 6));
         $this->assertTrue($this->isCheckDigitValid((int) substr($cardNumber, 0, 15), substr($cardNumber, -1)));
     }
 

--- a/tests/Fakers/Payment/CardNumberFakerTest.php
+++ b/tests/Fakers/Payment/CardNumberFakerTest.php
@@ -100,17 +100,21 @@ class CardNumberFakerTest extends TestCase
         $this->assertSame(0, $checkDigit);
     }
 
-    public function test_it_throws_an_exception_if_input_number_is_not_fifteen_digits(): void
+    public function test_it_throws_an_exception_if_input_number_is_less_than_fifteen_digits(): void
     {
         $this->expectException(RangeException::class);
         $this->expectExceptionMessage('The input number must have 15 digits, 14-digit number is given.');
 
         $faker = new CardNumberFaker($this->loader);
         $this->callProtectedMethod($faker, 'calculateCheckDigit', ['12345678901234']);
+    }
 
+    public function test_it_throws_an_exception_if_input_number_is_more_than_fifteen_digits(): void
+    {
         $this->expectException(RangeException::class);
         $this->expectExceptionMessage('The input number must have 15 digits, 16-digit number is given.');
 
+        $faker = new CardNumberFaker($this->loader);
         $this->callProtectedMethod($faker, 'calculateCheckDigit', ['1234567890123456']);
     }
 
@@ -181,6 +185,10 @@ class CardNumberFakerTest extends TestCase
 
         $faker->generate();
     }
+
+    // ----------------
+    // Helper Methods
+    // ----------------
 
     private function isCheckDigitValid(int $digits, string|int $checkDigit): bool
     {

--- a/tests/Fakers/Payment/ShebaFakerTest.php
+++ b/tests/Fakers/Payment/ShebaFakerTest.php
@@ -106,17 +106,21 @@ class ShebaFakerTest extends TestCase
         $this->assertTrue($this->isCheckNumberValid($number, $checkDigit));
     }
 
-    public function test_it_throws_an_exception_if_input_number_is_not_22_digits(): void
+    public function test_it_throws_an_exception_if_input_number_is_less_than_22_digits(): void
     {
         $this->expectException(RangeException::class);
         $this->expectExceptionMessage('The input number must have 22 digits, 21-digit number is given.');
 
         $faker = new ShebaFaker($this->loader);
         $this->callProtectedMethod($faker, 'calculateCheckNumber', ['123456789012345678901']);
+    }
 
+    public function test_it_throws_an_exception_if_input_number_is_more_than_22_digits(): void
+    {
         $this->expectException(RangeException::class);
         $this->expectExceptionMessage('The input number must have 22 digits, 23-digit number is given.');
 
+        $faker = new ShebaFaker($this->loader);
         $this->callProtectedMethod($faker, 'calculateCheckNumber', ['12345678901234567890123']);
     }
 
@@ -196,13 +200,17 @@ class ShebaFakerTest extends TestCase
         $faker->generate();
     }
 
+    // ----------------
+    // Helper Methods
+    // ----------------
+
     private function isCheckNumberValid(string $digits, string $checkDigit): bool
     {
         /*
         /--------------------------------------------------------------------------
         / Iran's Sheba Number Validation Algorithm
         /--------------------------------------------------------------------------
-        / The Iranian Sheba number follows the International Bank Account Number (IBAN) standard with some specific rules:
+        / It follows the International Bank Account Number (IBAN) standard with some specific rules:
         / - It is a 26-character string starting with 'IR' (the country code for Iran).
         / - The remaining characters are numeric and consist of:
         /   - A two-digit check number
@@ -214,7 +222,8 @@ class ShebaFakerTest extends TestCase
         / https://en.wikipedia.org/wiki/International_Bank_Account_Number
         /
         / Summary of Validation Algorithm:
-        / 1. Concatenate the 22-digit bank and account number, the numeric value of the country code, and the 2-digit check digit.
+        / 1. Concatenate the 22-digit bank and account number, the numeric value of the country code,
+        /    and the 2-digit check digit.
         / 2. Calculate the remainder of the division of this number by 97 — it should equal 1.
         /
         / Note: As the IBAN standard, 'IR' converts to 1827.

--- a/tests/Fakers/Payment/ShebaFakerTest.php
+++ b/tests/Fakers/Payment/ShebaFakerTest.php
@@ -70,7 +70,7 @@ class ShebaFakerTest extends TestCase
         $faker = new ShebaFaker($this->loader, bank: $bank);
         $bankCode = $this->callProtectedMethod($faker, 'getBankCode');
 
-        $this->assertSame($bankCode, $this->bankCodes[$bank]);
+        $this->assertSame($this->bankCodes[$bank], $bankCode);
     }
 
     public function test_it_generate_random_account_number_number(): void
@@ -173,7 +173,7 @@ class ShebaFakerTest extends TestCase
 
         $this->assertIsString($shebaNumber);
         $this->assertSame(26, strlen($shebaNumber));
-        $this->assertSame(substr($shebaNumber, 4, 3), $this->bankCodes[$bank]);
+        $this->assertSame($this->bankCodes[$bank], substr($shebaNumber, 4, 3));
         $this->assertTrue($this->isCheckNumberValid(substr($shebaNumber, 5), substr($shebaNumber, 2, 2)));
     }
 

--- a/tests/Fakers/Person/FirstNameFakerTest.php
+++ b/tests/Fakers/Person/FirstNameFakerTest.php
@@ -61,7 +61,7 @@ class FirstNameFakerTest extends TestCase
         $faker = new FirstNameFaker($this->loader, gender: null);
         $names = $this->callProtectedMethod($faker, 'getNames');
 
-        $this->assertEqualsCanonicalizing($names, $this->flatten($this->names));
+        $this->assertEqualsCanonicalizing($this->flatten($this->names), $names);
     }
 
     public function test_it_returns_names_of_specific_gender_when_gender_is_set(): void
@@ -71,7 +71,7 @@ class FirstNameFakerTest extends TestCase
         $faker = new FirstNameFaker($this->loader, gender: $gender);
         $names = $this->callProtectedMethod($faker, 'getNames');
 
-        $this->assertEqualsCanonicalizing($names, $this->names[$gender]);
+        $this->assertEqualsCanonicalizing($this->names[$gender], $names);
     }
 
     public function test_it_returns_fake_first_name(): void

--- a/tests/Fakers/Person/NationalCodeFakerTest.php
+++ b/tests/Fakers/Person/NationalCodeFakerTest.php
@@ -97,17 +97,21 @@ class NationalCodeFakerTest extends TestsTestCase
         $this->assertTrue($this->isCheckDigitValid($digits, $checkDigit));
     }
 
-    public function test_throws_an_exception_if_input_number_is_not_nine_digits(): void
+    public function test_throws_an_exception_if_input_number_is_less_than_nine_digits(): void
     {
         $this->expectException(RangeException::class);
         $this->expectExceptionMessage('The input number must have 9 digits, 8-digit number is given.');
 
         $faker = new NationalCodeFaker($this->loader);
         $this->callProtectedMethod($faker, 'calculateCheckDigit', ['12345678']);
+    }
 
+    public function test_throws_an_exception_if_input_number_is_more_than_nine_digits(): void
+    {
         $this->expectException(RangeException::class);
         $this->expectExceptionMessage('The input number must have 9 digits, 10-digit number is given.');
 
+        $faker = new NationalCodeFaker($this->loader);
         $this->callProtectedMethod($faker, 'calculateCheckDigit', ['1234567890']);
     }
 
@@ -153,6 +157,10 @@ class NationalCodeFakerTest extends TestsTestCase
         $faker = new NationalCodeFaker($this->loader, state: 'anonymous');
         $faker->generate();
     }
+
+    // ----------------
+    // Helper Methods
+    // ----------------
 
     private function isCheckDigitValid(string $digits, string|int $checkDigit): bool
     {

--- a/tests/Fakers/Person/TitleFakerTest.php
+++ b/tests/Fakers/Person/TitleFakerTest.php
@@ -61,7 +61,7 @@ class TitleFakerTest extends TestCase
         $faker = new TitleFaker($this->loader, gender: null);
         $titles = $this->callProtectedMethod($faker, 'getTitles');
 
-        $this->assertEqualsCanonicalizing($titles, $this->flatten($this->titles));
+        $this->assertEqualsCanonicalizing($this->flatten($this->titles), $titles);
     }
 
     public function test_it_returns_titles_of_specific_gender_when_gender_is_set(): void
@@ -71,7 +71,7 @@ class TitleFakerTest extends TestCase
         $faker = new TitleFaker($this->loader, gender: $gender);
         $titles = $this->callProtectedMethod($faker, 'getTitles');
 
-        $this->assertEqualsCanonicalizing($titles, $this->titles[$gender]);
+        $this->assertEqualsCanonicalizing($this->titles[$gender], $titles);
     }
 
     public function test_it_returns_fake_title(): void

--- a/tests/Fakers/Phone/CellPhoneFakerTest.php
+++ b/tests/Fakers/Phone/CellPhoneFakerTest.php
@@ -63,7 +63,7 @@ class CellPhoneFakerTest extends TestCase
         $faker = new CellPhoneFaker($this->loader, provider: null);
         $prefixes = $this->callProtectedMethod($faker, 'getPrefixes');
 
-        $this->assertEqualsCanonicalizing($prefixes, $this->flatten($this->phonePrefixes));
+        $this->assertEqualsCanonicalizing($this->flatten($this->phonePrefixes), $prefixes);
     }
 
     public function test_it_returns_prefixes_of_specific_provider_when_provider_is_set(): void
@@ -73,7 +73,7 @@ class CellPhoneFakerTest extends TestCase
         $faker = new CellPhoneFaker($this->loader, provider: $provider);
         $prefixes = $this->callProtectedMethod($faker, 'getPrefixes');
 
-        $this->assertEqualsCanonicalizing($prefixes, $this->phonePrefixes[$provider]);
+        $this->assertEqualsCanonicalizing($this->phonePrefixes[$provider], $prefixes);
 
     }
 

--- a/tests/Fakers/Phone/PhoneNumberFakerTest.php
+++ b/tests/Fakers/Phone/PhoneNumberFakerTest.php
@@ -68,7 +68,7 @@ class PhoneNumberFakerTest extends TestCase
         $faker = new PhoneNumberFaker($this->loader, state: $state);
         $statePrefix = $this->callProtectedMethod($faker, 'getStatePrefix');
 
-        $this->assertSame($statePrefix, $this->statePrefixes[$state]);
+        $this->assertSame($this->statePrefixes[$state], $statePrefix);
     }
 
     public function test_it_generates_random_eight_digit_number(): void
@@ -119,7 +119,7 @@ class PhoneNumberFakerTest extends TestCase
 
         $this->assertIsString($phoneNumber);
         $this->assertSame(11, strlen($phoneNumber));
-        $this->assertSame(substr($phoneNumber, 0, 3), $this->statePrefixes[$state]);
+        $this->assertSame($this->statePrefixes[$state], substr($phoneNumber, 0, 3));
     }
 
     public function test_it_throws_an_exception_with_invalid_state_name(): void

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -225,7 +225,7 @@ class GeneratorTest extends TestCase
         $phoneNumber = $this->generator->phoneNumber($separator, $state);
 
         $this->assertIsString($phoneNumber);
-        $this->assertSame(substr($phoneNumber, 0, 3), $statePrefixes[$state]);
+        $this->assertSame($statePrefixes[$state], substr($phoneNumber, 0, 3));
         $this->assertSame(3, strpos($phoneNumber, (string) $separator));
     }
 


### PR DESCRIPTION
### What is the reason for this PR?

Tests that include exception assertions are separated to ensure the entire test runs correctly. The convention for the order of arguments in `equals`/`same` assertions is corrected.

- [ ] A new feature
- [x] Fixed an issue (only test conventions)

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [ ] New features and changes are [documented](../README.md)

### Summary of changes

- Exception tests are separated.
- The order of expected and actual parameters is fixed in `equals` and `same` assertions.

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer