### PR TITLE
Chore: improve number readability by adding thousand separators

### DIFF
--- a/src/Fakers/Payment/CardNumberFaker.php
+++ b/src/Fakers/Payment/CardNumberFaker.php
@@ -76,7 +76,7 @@ class CardNumberFaker implements FakerInterface
 
     protected function generateRandomCardNumber(): int
     {
-        return random_int(100000000, 999999999);
+        return random_int(100_000_000, 999_999_999);
     }
 
     /**

--- a/src/Fakers/Payment/ShebaFaker.php
+++ b/src/Fakers/Payment/ShebaFaker.php
@@ -81,7 +81,7 @@ class ShebaFaker implements FakerInterface
 
     protected function generateRandomAccountNumber(): string
     {
-        return random_int(100000000, 999999999).random_int(0, 999999);
+        return random_int(100_000_000, 999_999_999).random_int(0, 999_999);
     }
 
     protected function fillEmptyPlaces(string $number): string

--- a/src/Fakers/Person/NationalCodeFaker.php
+++ b/src/Fakers/Person/NationalCodeFaker.php
@@ -77,7 +77,7 @@ class NationalCodeFaker implements FakerInterface
 
     protected function generateRandomNationalCode(): int
     {
-        return random_int(100000, 999999);
+        return random_int(100_000, 999_999);
     }
 
     /**

--- a/src/Fakers/Phone/CellPhoneFaker.php
+++ b/src/Fakers/Phone/CellPhoneFaker.php
@@ -73,7 +73,7 @@ class CellPhoneFaker implements FakerInterface
 
     protected function generateRandomCellPhone(): string
     {
-        return (string) random_int(1000000, 9999999);
+        return (string) random_int(1_000_000, 9_999_999);
     }
 
     protected function formatPhone(string $providerPrefix, string $phoneNumber): string

--- a/src/Fakers/Phone/PhoneNumberFaker.php
+++ b/src/Fakers/Phone/PhoneNumberFaker.php
@@ -64,7 +64,7 @@ class PhoneNumberFaker implements FakerInterface
 
     protected function generateRandomPhoneNumber(): string
     {
-        return (string) random_int(10000000, 99999999);
+        return (string) random_int(10_000_000, 99_999_999);
     }
 
     protected function formatPhone(string $statePrefix, string $phoneNumber): string

--- a/tests/Fakers/Payment/CardNumberFakerTest.php
+++ b/tests/Fakers/Payment/CardNumberFakerTest.php
@@ -84,7 +84,7 @@ class CardNumberFakerTest extends TestCase
 
     public function test_it_calculate_check_digit(): void
     {
-        $number = random_int(100000000000000, 999999999999999);
+        $number = (string) random_int(100_000_000_000_000, 999_999_999_999_999);
 
         $faker = new CardNumberFaker($this->loader);
         $checkDigit = $this->callProtectedMethod($faker, 'calculateCheckDigit', [$number]);
@@ -95,7 +95,7 @@ class CardNumberFakerTest extends TestCase
     public function test_it_calculate_check_digit_if_sum_is_multiple_of_ten(): void
     {
         $faker = new CardNumberFaker($this->loader);
-        $checkDigit = $this->callProtectedMethod($faker, 'calculateCheckDigit', [456789777221862]);
+        $checkDigit = $this->callProtectedMethod($faker, 'calculateCheckDigit', ['456789777221862']);
 
         $this->assertSame(0, $checkDigit);
     }
@@ -146,7 +146,7 @@ class CardNumberFakerTest extends TestCase
         $this->assertIsNumeric($cardNumber);
         $this->assertSame(16, strlen($cardNumber));
         $this->assertContains(substr($cardNumber, 0, 6), $this->banksBins);
-        $this->assertTrue($this->isCheckDigitValid((int) substr($cardNumber, 0, 15), substr($cardNumber, -1)));
+        $this->assertTrue($this->isCheckDigitValid(substr($cardNumber, 0, 15), substr($cardNumber, -1)));
     }
 
     public function test_it_returns_fake_card_number_for_specific_bank(): void
@@ -160,7 +160,7 @@ class CardNumberFakerTest extends TestCase
         $this->assertIsNumeric($cardNumber);
         $this->assertSame(16, strlen($cardNumber));
         $this->assertSame($this->banksBins[$bank], substr($cardNumber, 0, 6));
-        $this->assertTrue($this->isCheckDigitValid((int) substr($cardNumber, 0, 15), substr($cardNumber, -1)));
+        $this->assertTrue($this->isCheckDigitValid(substr($cardNumber, 0, 15), substr($cardNumber, -1)));
     }
 
     public function test_it_returns_fake_card_number_with_specific_separator(): void
@@ -173,7 +173,7 @@ class CardNumberFakerTest extends TestCase
 
         $cardNumberDigits = str_replace('-', '', $cardNumber);
         $this->assertContains(substr($cardNumberDigits, 0, 6), $this->banksBins);
-        $this->assertTrue($this->isCheckDigitValid((int) substr($cardNumberDigits, 0, 15), substr($cardNumberDigits, -1)));
+        $this->assertTrue($this->isCheckDigitValid(substr($cardNumberDigits, 0, 15), substr($cardNumberDigits, -1)));
     }
 
     public function test_it_throws_an_exception_if_bank_name_is_not_valid(): void
@@ -190,7 +190,7 @@ class CardNumberFakerTest extends TestCase
     // Helper Methods
     // ----------------
 
-    private function isCheckDigitValid(int $digits, string|int $checkDigit): bool
+    private function isCheckDigitValid(string $digits, string|int $checkDigit): bool
     {
         /*
         /-------------------------------------
@@ -213,7 +213,7 @@ class CardNumberFakerTest extends TestCase
         */
 
         $sum = 0;
-        foreach (str_split((string) $digits) as $key => $value) {
+        foreach (str_split($digits) as $key => $value) {
             $multipleBy = (($key + 1) % 2 === 0) ? 1 : 2;
 
             $product = $value * $multipleBy;

--- a/tests/Fakers/Payment/ShebaFakerTest.php
+++ b/tests/Fakers/Payment/ShebaFakerTest.php
@@ -85,13 +85,13 @@ class ShebaFakerTest extends TestCase
 
     public function test_it_fills_remain_places_with_0(): void
     {
-        $number = random_int(1000000000, 99999999999999);
+        $number = (string) random_int(1_000_000_000, 99_999_999_999_999);
 
         $faker = new ShebaFaker($this->loader);
         $filledNumber = $this->callProtectedMethod($faker, 'fillEmptyPlaces', [$number]);
 
         $this->assertSame(18, strlen((string) $filledNumber));
-        $this->assertMatchesRegularExpression('/^0+$/', str_replace((string) $number, '', $filledNumber));
+        $this->assertMatchesRegularExpression('/^0+$/', str_replace($number, '', $filledNumber));
     }
 
     public function test_it_calculate_check_digit(): void

--- a/tests/Fakers/Person/LastNameFakerTest.php
+++ b/tests/Fakers/Person/LastNameFakerTest.php
@@ -6,7 +6,7 @@ namespace AliYavari\PersianFaker\Fakers\Person;
 
 use AliYavari\PersianFaker\Contracts\DataLoaderInterface;
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class LastNameFakerTest extends TestCase
 {

--- a/tests/Fakers/Person/NationalCodeFakerTest.php
+++ b/tests/Fakers/Person/NationalCodeFakerTest.php
@@ -11,10 +11,10 @@ use AliYavari\PersianFaker\Exceptions\InvalidStateNameException;
 use AliYavari\PersianFaker\Fakers\Person\NationalCodeFaker;
 use Mockery;
 use RangeException;
-use Tests\TestCase as TestsTestCase;
+use Tests\TestCase;
 use TypeError;
 
-class NationalCodeFakerTest extends TestsTestCase
+class NationalCodeFakerTest extends TestCase
 {
     use Arrayable, Randomable;
 
@@ -89,7 +89,7 @@ class NationalCodeFakerTest extends TestsTestCase
 
     public function test_it_calculate_check_digit(): void
     {
-        $digits = (string) random_int(100000000, 999999999);
+        $digits = (string) random_int(100_000_000, 999_999_999);
 
         $faker = new NationalCodeFaker($this->loader);
         $checkDigit = $this->callProtectedMethod($faker, 'calculateCheckDigit', [$digits]);

--- a/tests/Fakers/Text/ParagraphFakerTest.php
+++ b/tests/Fakers/Text/ParagraphFakerTest.php
@@ -94,7 +94,7 @@ class ParagraphFakerTest extends TestCase
         $number = $this->callProtectedMethod($faker, 'getVariableSentencesNumber');
 
         $this->assertIsInt($number);
-        $this->assertSame(1, $number); // min is 1
+        $this->assertSame(1, $number); // Min is 1
     }
 
     public function test_it_returns_max_valid_number_as_variable_number_if_calculated_number_is_greater_than_it(): void
@@ -103,7 +103,7 @@ class ParagraphFakerTest extends TestCase
         $number = $this->callProtectedMethod($faker, 'getVariableSentencesNumber');
 
         $this->assertIsInt($number);
-        $this->assertSame(100, $number); // max is 100
+        $this->assertSame(100, $number); // Max is 100
     }
 
     public function test_it_returns_multiple_sentences_as_paragraph(): void

--- a/tests/Fakers/Text/SentenceFakerTest.php
+++ b/tests/Fakers/Text/SentenceFakerTest.php
@@ -95,7 +95,7 @@ class SentenceFakerTest extends TestCase
         $number = $this->callProtectedMethod($faker, 'getVariableWordsNumber');
 
         $this->assertIsInt($number);
-        $this->assertSame(1, $number); // min is 1
+        $this->assertSame(1, $number); // Min is 1
     }
 
     public function test_it_returns_max_valid_number_as_variable_number_if_calculated_number_is_greater_than_it(): void
@@ -104,7 +104,7 @@ class SentenceFakerTest extends TestCase
         $number = $this->callProtectedMethod($faker, 'getVariableWordsNumber');
 
         $this->assertIsInt($number);
-        $this->assertSame(100, $number); // max is 100
+        $this->assertSame(100, $number); // Max is 100
     }
 
     public function test_it_adds_dot_at_the_end_of_a_sentence(): void

--- a/tests/Fakers/Text/TextFakerTest.php
+++ b/tests/Fakers/Text/TextFakerTest.php
@@ -27,7 +27,7 @@ class TextFakerTest extends TestCase
 
     public function test_chars_number_validation_passes_when_the_number_is_in_valid_range(): void
     {
-        $number = random_int(10, 1000);
+        $number = random_int(10, 1_000);
 
         $faker = new TextFaker($this->loader, maxNbChars: $number);
         $isValid = $this->callProtectedMethod($faker, 'isCharsNumberValid');
@@ -37,7 +37,7 @@ class TextFakerTest extends TestCase
 
     public function test_chars_number_validation_fails_when_the_number_is_in_valid_range(): void
     {
-        $number = $this->getOneRandomElement([-1, 9, 1001]);
+        $number = $this->getOneRandomElement([-1, 9, 1_001]);
 
         $faker = new TextFaker($this->loader, maxNbChars: $number);
         $isValid = $this->callProtectedMethod($faker, 'isCharsNumberValid');

--- a/tests/Fakers/Text/WordFakerTest.php
+++ b/tests/Fakers/Text/WordFakerTest.php
@@ -25,7 +25,7 @@ class WordFakerTest extends TestCase
         parent::setUp();
 
         $this->loader = Mockery::mock(DataLoaderInterface::class);
-        $this->loader->shouldReceive('get')->once()->andReturn($this->words);
+        $this->loader->shouldReceive('get')->once()->andReturn($this->words)->byDefault();
     }
 
     public function test_it_returns_specific_number_of_words(): void
@@ -121,6 +121,8 @@ class WordFakerTest extends TestCase
 
     public function test_it_returns_new_instance_with_configs_to_return_as_string_with_custom_words_number(): void
     {
+        $this->loader->shouldReceive('get')->twice()->andReturn($this->words);
+
         $faker = new WordFaker($this->loader, nbWords: 2, asText: false);
         $newFaker = $faker->shouldReturnString(5);
 

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -8,7 +8,6 @@ use AliYavari\PersianFaker\Contracts\GeneratorInterface;
 use AliYavari\PersianFaker\Cores\Randomable;
 use AliYavari\PersianFaker\DataLoader;
 use AliYavari\PersianFaker\Generator;
-use PHPUnit\Framework\TestCase;
 
 /**
  * This includes integration tests

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use Mockery;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use ReflectionMethod;
 
@@ -14,5 +15,12 @@ class TestCase extends BaseTestCase
         $reflectedMethod = new ReflectionMethod($obj, $method);
 
         return $reflectedMethod->invoke($obj, ...$args);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Mockery::close();
     }
 }


### PR DESCRIPTION
### What is the reason for this PR?

This PR is only for clean code. To make numbers more readable, thousand separators are added to them.

- [ ] A new feature
- [x] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [ ] New features and changes are [documented](../README.md)

### Summary of changes

- Add thousand separators to numbers.
- Minor improvements to make tests and code more consistent.

### Review checklist

- [x] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer