### PR TITLE
Feature: add persian_faker helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /composer.lock
 /phpunit.xml
 /.vscode/
+/.idea/
 /vendor/
 *.swp
 *.swo

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ You can easily create an instance of Faker in your PHP projects by calling the `
 $persianFaker = \AliYavari\PersianFaker\Factory::create();
 ```
 
+### Usage Helper
+
+If you prefer a simpler way to get a Persian Faker instance, you can use the global `persian_faker()` helper function provided by this package. This is especially useful in Laravel or any PHP project where global helpers are available.
+
+```php
+$persianFaker = persian_faker();
+```
+
+This helper will automatically resolve the Faker instance, using the Laravel service container if available, or falling back to a direct instantiation otherwise.
+
 ## Available Methods
 
 Most methods in `persian-faker-php` are extensions of the [fakerphp/faker](https://fakerphp.org/) library, supporting only Persian language and Iran-specific data. The implementation and arguments for these methods are the same as those in the original Faker library.

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "symfony/var-dumper": "^7.1.6"
     },
     "autoload": {
+        "files": [
+            "helpers.php"
+        ],
         "psr-4": {
             "AliYavari\\PersianFaker\\": "src/"
         }

--- a/docs/en/01_getting_started.md
+++ b/docs/en/01_getting_started.md
@@ -24,6 +24,14 @@ You can easily create an instance of Faker in your PHP projects by calling the `
 $persianFaker = \AliYavari\PersianFaker\Factory::create();
 ```
 
+## Usage Helper
+
+If you prefer a simpler way to get a Persian Faker instance, you can use the global `persian_faker()` helper function provided by this package. This is especially useful in Laravel or any PHP project where global helpers are available.
+
+```php
+$persianFaker = persian_faker();
+```
+
 ## Available Methods
 
 Most methods in `persian-faker-php` are extensions of the [fakerphp/faker](https://fakerphp.org/) library, supporting only Persian language and Iran-specific data. The implementation and arguments for these methods are the same as those in the original Faker library.

--- a/docs/fa/01_getting_started.md
+++ b/docs/fa/01_getting_started.md
@@ -24,6 +24,14 @@ composer require --dev amyavari/persian-faker-php
 $persianFaker = \AliYavari\PersianFaker\Factory::create();
 ```
 
+## فراخوانی از طریق Helper
+
+اگر به جای اینکه از فراخوانی کلاس `Factory` استفاده کنید، می توانید از فراخوانی Helper استفاده کنید:
+
+```php
+$persianFaker = persian_faker();
+```
+
 ## توابع موجود
 
 اکثر توابع کتابخانه `persian-faker-php` فقط پیاده سازی توابع کتابخانه [fakerphp/faker](https://fakerphp.org/) برای پشتیبانی از زبان فارسی و اطلاعات کشور ایران می باشد. پیاده سازی، آرگومان های ورودی و خروجی عیناً مانند کتابخانه اصلی پیاده سازی شده اند.

--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use AliYavari\PersianFaker\Factory;
+use AliYavari\PersianFaker\Generator;
+
+if (! function_exists('persian_faker') && class_exists(Factory::class)) {
+    /**
+     * Get a persian faker instance.
+     */
+    function persian_faker(): Generator
+    {
+        if (! class_exists('Illuminate\Foundation\Application') && ! function_exists('app')) {
+            return Factory::create();
+        }
+
+        $abstract = 'persianFaker';
+
+        if (! app()->bound($abstract)) {
+            app()->singleton($abstract, fn () => Factory::create());
+        }
+
+        return app()->make($abstract);
+    }
+}

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -503,4 +503,13 @@ class GeneratorTest extends TestCase
         $this->assertIsString($color);
         $this->assertContains($color, $this->flatten($colors));
     }
+
+    public function test_persian_faker_helper_returns_generator_instance_and_works(): void
+    {
+        $faker = persian_faker();
+        $this->assertInstanceOf(\AliYavari\PersianFaker\Generator::class, $faker);
+        $name = $faker->name();
+        $this->assertIsString($name);
+        $this->assertNotEmpty($name);
+    }
 }


### PR DESCRIPTION
### What is the reason for this PR?

This feature introduces a convenient global helper function, `persian_faker()`, to simplify the process of obtaining a Persian Faker instance in PHP projects. The helper is especially useful for Laravel users or any PHP project where global helpers are available.

- [x] A new feature
- [ ] Fixed an issue

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [x] New features and changes are [documented](../README.md)

### Summary of changes

- Added a global `persian_faker()` function in `helpers.php` that returns a Persian Faker generator instance.
- The helper uses the Laravel service container if available, or falls back to direct instantiation otherwise.
- Registered the helpers file in Composer's autoload for seamless usage.
- Updated documentation and usage examples in the README and docs.
- Added tests to ensure the helper works as expected.

### Review checklist

- [] All checks have passed
- [] Changes are added to the `CHANGELOG.md`
- [ ] Changes are approved by maintainer