### PR TITLE
ci: schedule tests and skip runs for documentation-only updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,18 @@ name: Tests
 
 on:
   push:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
     branches:
       - main
       - ci/test
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   tests:


### PR DESCRIPTION
### What is the reason for this PR?

To ensure the package remains compatible with new PHP versions and other dependencies, daily test runs have been scheduled. Additionally, documentation-only updates are now excluded from triggering tests.	

- [x] A new feature
- [ ] Fixed an issue (resolve #ID)

### Author's checklist

- [x] Follow the [Contribution Guide](../CONTRIBUTING.md)
- [ ] New features and changes are [documented](../README.md)

### Summary of changes

- Added scheduled tests (daily)
- Skipped runs for documentation-only updates

### Review checklist

- [ ] All checks have passed
- [ ] Changes are added to the `CHANGELOG.md`
- [x] Changes are approved by maintainer
